### PR TITLE
fix/feat: 주월간 데이터 마지막 일 안받아오는 오류 수정 / dday 한개만 가져오기 api 기능 추가

### DIFF
--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -169,3 +169,10 @@ exports.getNickCheck = async (req, res) => {
   const result = await profileService.getNickCheck(user, nickname);
   return res.status(StatusCodes.OK).json({ ok: result });
 };
+
+
+exports.getDdayOne = async (req, res) => {
+  const user = req.locals;
+  const myDday = await profileService.getDdayOne(user);
+  return res.status(StatusCodes.OK).json({ myDday });
+};

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -19,6 +19,9 @@ router
   .route("/dday")
   .get(asyncWrapper(Profile.getDday))
   .post(asyncWrapper(Profile.postDday));
+  router
+  .route("/ddayOne")
+  .get(asyncWrapper(Profile.getDdayOne));
 router
   .route("/dday/:id")
   .put(asyncWrapper(Profile.putDday))

--- a/service/myPage.js
+++ b/service/myPage.js
@@ -14,7 +14,7 @@ exports.getStudyTime = async (user, yearMonth) => {
     DateTime.fromISO(`${year}-${month}-01`).startOf("months").plus({ hours: 2 })
   );
   const endOfMonth = new Date(
-    DateTime.fromISO(`${year}-${month}-01`).endOf("months").plus({ hours: 2 })
+    DateTime.fromISO(`${year}-${month}-01`).endOf("months").plus({days:1}).plus({ hours: 2 })
   );
   //const startOfMonth = moment().format(`${year}-${month}-01`);
   //const endOfMonth = moment().format(`${year}-${month}-`) + moment().daysInMonth();
@@ -45,10 +45,11 @@ exports.getWeeklyTime = async (user, startWeek, endWeek) => {
     throw new BadRequestError("날짜 형식이 틀립니다.");
   }
   const startOfWeek = new Date(DateTime.fromISO(startWeek).plus({ hours: 2 }));
-  const endOfWeek = new Date(DateTime.fromISO(endWeek).plus({ hours: 2 }));
+  const endOfWeek = new Date(DateTime.fromISO(endWeek).plus({days:1}).plus({ hours: 2 }));
 
+  console.log(endOfWeek)
   const totalWeekTime =  await myPageModel.getStudyTime(user, startOfWeek, endOfWeek);
-  
+  console.log(totalWeekTime);
   const weeklyData = [];
   if (totalWeekTime.length > 0) {
     totalWeekTime.forEach((element) => {

--- a/service/profile.js
+++ b/service/profile.js
@@ -176,7 +176,7 @@ exports.getNickCheck = async (user, nickname) => {
 };
 
 exports.getDdayOne = async (user) => {
-  const today = DateTime.now().toMillis();
+  const today = DateTime.now().minus({days:1}).toMillis();
   const myProfile = await profileModels.getProfile(user);
 
   if (myProfile) {

--- a/service/profile.js
+++ b/service/profile.js
@@ -1,6 +1,7 @@
 const profileModels = require("../models/profile");
 const userModels = require("../models/userValidation");
 const { NotFoundError } = require("../errors");
+const { DateTime } = require("luxon");
 
 exports.getProfile = async (user) => {
   let myProfile = {};
@@ -171,5 +172,29 @@ exports.getNickCheck = async (user, nickname) => {
     return false;
   } else {
     return true;
+  }
+};
+
+exports.getDdayOne = async (user) => {
+  const today = DateTime.now().toMillis();
+  const myProfile = await profileModels.getProfile(user);
+
+  if (myProfile) {
+    const myDday = myProfile.dDay;
+    const myDdayFilter = myDday.filter((dday)=>{
+      const day = DateTime.fromISO(dday.deadline).toMillis();
+      return today<day;
+    })
+    if(myDdayFilter.length){
+      return [myDdayFilter.sort(
+        (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+      )[0]];
+    }
+    else {
+      return [];
+    }
+
+  } else {
+    throw new NotFoundError("프로필이 존재하지 않습니다.");
   }
 };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,14 @@
 const process = require('process');
-
+const { DateTime } = require("luxon");
 const logDir = `${process.cwd()}/ogs`;
 
 console.log(logDir);
+
+const startOfWeek = new Date(DateTime.fromISO("2022-09-26").plus({ hours: 2 }));
+console.log(startOfWeek.toISOString())
+
+const a =new Date()
+console.log(a)
+
+const day = DateTime.fromISO(a.toISOString());
+console.log(day.toISODate())


### PR DESCRIPTION
fix: 주간/월간 데이터 마지막 일 안받아오는 오류 수정
  - 주의 시작일/끝일 을 검색 시 끝일의 시작 시간까지만 가져와서 마지막 날 데이터 안받아오는 오류 발생
     ex) 시작 1일~7일 일 때 1일<= data <7일
  - 끝일까지 데이터를 가져오게 수정
     ex) 1일 <= data <=7일

feat: dday 한개만 가져오기 api 기능 추가
  - front에서 추가 기능 요청
  - main화면에서 dday get 기능을 최근일자로 한개만 가져오는 기능 요청
  - 지난 dday는 가져오지 않음. 가장 가까운 dday만 한개 가져오기
  - 만약 모든 dday가 오늘일자보다 앞인 경우 빈배열 가져오기 